### PR TITLE
chore: Add test comment to sketchybar config

### DIFF
--- a/modules/darwin/sketchybar/default.nix
+++ b/modules/darwin/sketchybar/default.nix
@@ -12,6 +12,7 @@ in
     # config = builtins.readFile ./sketchybarrc;
   };
 
+  # pr test claude code
   system.activationScripts.extraActivation.text = ''
     sudo -u ${username} mkdir -p ${userHome}/.config/sketchybar
     sudo -u ${username} ln -sf ${sketchybarSourcePath}/sketchybarrc ${userHome}/.config/sketchybar/sketchybarrc


### PR DESCRIPTION
## Summary
- Adds a test comment to the sketchybar default configuration file to test PR creation workflow

## Test plan
- [ ] Verify the comment is present in `modules/darwin/sketchybar/default.nix`
- [x] Ensure no functional changes to the sketchybar setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)